### PR TITLE
Update svg-to-js.py to ignore the .DS_Store file on macOS

### DIFF
--- a/svg-to-js.py
+++ b/svg-to-js.py
@@ -57,7 +57,7 @@ js.write("""var icons = {
 for filename in sorted(os.listdir("icon-svg")):
     icon = os.path.join("icon-svg", filename)
     # checking if it is a file
-    if os.path.isfile(icon):
+    if os.path.isfile(icon) and filename != '.DS_Store':
         svg = open(icon, 'r').read()
 
         # Parse SVG as XML


### PR DESCRIPTION
I just spent way more time than I'd like to admit debugging why I got a UTF-8 decoding error while running the script on macOS 🙃

Here's a small fix to ignore the `.DS_Store` file that could exist in the input directory which might save someone else some trouble on Mac.

Great tool btw, thanks for your work! 
 